### PR TITLE
cmd/pepperlint: fixing various bugs that #13 inadvertently found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ all: unit
 
 unit: build verify
 	@echo "Testing all pepperlint packages"
-	@go test -v ./...
+	@go test -cover -v ./...
 
 unit-race: build verify
 	@echo "Testing all pepperlint packages with race enabled"
-	@go test -v -race -cpu=1,2,4 ./...
+	@go test -cover -v -race -cpu=1,2,4 ./...
 
 build: get-deps
 	@echo "Building pepperlint packages"

--- a/cache.go
+++ b/cache.go
@@ -247,6 +247,15 @@ func (c *Cache) Visit(node ast.Node) ast.Visitor {
 			break
 		}
 
+		// Issue #13
+		//
+		// Was squashing over package names that may exist in the same package
+		// but contain a pkg_test format. That would mean all previous cached
+		// files would be lost
+		if _, ok := c.Packages[c.currentPkgImportPath]; ok {
+			return c
+		}
+
 		c.Packages[c.currentPkgImportPath] = &Package{
 			Name: GetPackageNameFromImportPath(c.currentPkgImportPath),
 		}

--- a/cmd/pepperlint/main.go
+++ b/cmd/pepperlint/main.go
@@ -254,7 +254,7 @@ func main() {
 
 	errs := suppress(config.Suppressions, v.Errors)
 	if len(errs) != 0 {
-		fmt.Fprintf(os.Stderr, "%v", errs)
+		fmt.Fprintf(os.Stderr, "%v", pepperlint.Errors(errs))
 		os.Exit(1)
 	}
 }

--- a/rules/core/deprecated_field_rule.go
+++ b/rules/core/deprecated_field_rule.go
@@ -78,6 +78,10 @@ func (r DeprecatedFieldRule) isDeprecatedField(expr *ast.SelectorExpr) error {
 		}
 	}
 
+	if info.Spec == nil {
+		return nil
+	}
+
 	depField := r.helper.GetFieldByName(expr.Sel.Name, info.Spec)
 	if depField == nil {
 		return nil
@@ -112,6 +116,10 @@ func (r DeprecatedFieldRule) checkBinaryExprFields(bexpr *ast.BinaryExpr) []erro
 
 			info, ok := infos.GetByVarName(ident.Name)
 			if !ok {
+				continue
+			}
+
+			if info.Spec == nil {
 				continue
 			}
 

--- a/rules/core/deprecated_op_rule.go
+++ b/rules/core/deprecated_op_rule.go
@@ -125,7 +125,9 @@ func (r *DeprecatedOpRule) getExternalTypeSpec(rhs ast.Expr) (pepperlint.TypeInf
 		importPath := file.Imports[pkgName]
 		pkg, ok := r.helper.PackagesCache.Packages.Get(importPath)
 		if !ok {
-			panic(fmt.Errorf("package, %q, does not exist in cache", importPath))
+			// this occurs when an import from the standard library is called or any
+			// other import that wasn't included in the config or cli by using -include-pkgs
+			return pepperlint.TypeInfo{}, false
 		}
 
 		info, ok := pkg.Files.GetTypeInfo(typeName)

--- a/rules/core/deprecated_struct_rule.go
+++ b/rules/core/deprecated_struct_rule.go
@@ -284,9 +284,17 @@ func (r DeprecatedStructRule) checkTypeAliases(rhs ast.Node, expr ast.Expr) []er
 
 	switch t := expr.(type) {
 	case *ast.Ident:
+		if t.Obj == nil {
+			return nil
+		}
+
+		if t.Obj.Decl == nil {
+			return nil
+		}
+
 		spec, ok := t.Obj.Decl.(*ast.TypeSpec)
 		if !ok {
-			return errs
+			return nil
 		}
 
 		pkg, ok := r.helper.PackagesCache.CurrentPackage()
@@ -296,7 +304,7 @@ func (r DeprecatedStructRule) checkTypeAliases(rhs ast.Node, expr ast.Expr) []er
 
 		info, ok := pkg.Files.GetTypeInfo(spec.Name.Name)
 		if !ok {
-			return errs
+			return nil
 		}
 
 		if hasDeprecatedComment(info.Doc) {


### PR DESCRIPTION
Fixes #13 

Package cache was stomping over package entries if there are test packages in the package directory, ie pkg and pkg_test. This change fixes upon that by simply not recreating the entry if it already exists.