### PR TITLE
moving deprecated to its own pkg along with adding aws rules

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -36,7 +36,7 @@ func TestCacheCurrentPackage(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			cache := Cache{
 				Packages:             c.packages,
-				currentPkgImportPath: c.pkgImportPath,
+				CurrentPkgImportPath: c.pkgImportPath,
 			}
 
 			pkg, ok := cache.CurrentPackage()
@@ -107,8 +107,8 @@ func TestCacheCurrentFile(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			cache := Cache{
 				Packages:             c.packages,
-				currentPkgImportPath: c.pkgImportPath,
-				currentFile:          c.fileAST,
+				CurrentPkgImportPath: c.pkgImportPath,
+				CurrentASTFile:       c.fileAST,
 			}
 
 			file, ok := cache.CurrentFile()
@@ -235,7 +235,7 @@ func TestCacheGetTypeInfo(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			cache := Cache{
 				Packages:             c.packages,
-				currentPkgImportPath: c.pkgImportPath,
+				CurrentPkgImportPath: c.pkgImportPath,
 			}
 
 			pkg, ok := cache.CurrentPackage()
@@ -303,7 +303,7 @@ func TestCacheGetOpInfo(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			cache := Cache{
 				Packages:             c.packages,
-				currentPkgImportPath: c.pkgImportPath,
+				CurrentPkgImportPath: c.pkgImportPath,
 			}
 
 			pkg, ok := cache.CurrentPackage()

--- a/cmd/pepperlint/main.go
+++ b/cmd/pepperlint/main.go
@@ -158,9 +158,9 @@ func walk(v ast.Visitor, p []Packages) {
 // lint will lint the dir while walking the dirs provided to grab necessary metadata
 // from to then validate the dir with the gathered metadata.
 func lint(config Config, pkgs []string, pkg string) (*pepperlint.Visitor, Container, error) {
-	// Prepends go path
 	gopath := filepath.Join(os.Getenv("GOPATH"), "src")
-	pkg = filepath.Join(gopath, pkg)
+
+	// Prepends go path to each package in pkgs
 	for i, p := range pkgs {
 		pkgs[i] = filepath.Join(gopath, p)
 	}

--- a/cmd/pepperlint/main_test.go
+++ b/cmd/pepperlint/main_test.go
@@ -15,7 +15,7 @@ func TestMain(t *testing.T) {
 		expectedLineNumbers []int
 	}{
 		{
-			mainPackage: "github.com/go-toolset/pepperlint/cmd/pepperlint/testdata/core",
+			mainPackage: "./testdata/core",
 			includeDirs: []string{
 				"github.com/go-toolset/pepperlint/cmd/pepperlint/testdata/deprecated",
 			},
@@ -49,10 +49,11 @@ func TestMain(t *testing.T) {
 		config := Config{
 			Rules: Rules{
 				{
-					RuleName: "deprecated",
+					RuleName: "core/deprecated",
 				},
 			},
 		}
+
 		v, _, err := lint(config, c.includeDirs, c.mainPackage)
 		if err != nil {
 			t.Fatal(err)

--- a/cmd/pepperlint/rules_registry.go
+++ b/cmd/pepperlint/rules_registry.go
@@ -1,5 +1,6 @@
 package main
 
 import (
-	_ "github.com/go-toolset/pepperlint/rules/core"
+	_ "github.com/go-toolset/pepperlint/rules/aws"
+	_ "github.com/go-toolset/pepperlint/rules/core/deprecated"
 )

--- a/rules.go
+++ b/rules.go
@@ -61,6 +61,7 @@ func (r *Rules) Merge(otherRules Rules) *Rules {
 	r.CallExprRules = append(r.CallExprRules, otherRules.CallExprRules...)
 	r.BinaryExprRules = append(r.BinaryExprRules, otherRules.BinaryExprRules...)
 	r.ReturnStmtRules = append(r.ReturnStmtRules, otherRules.ReturnStmtRules...)
+	r.FileRules = append(r.FileRules, otherRules.FileRules...)
 
 	return r
 }

--- a/rules/aws/dynamodb_expression_rules.go
+++ b/rules/aws/dynamodb_expression_rules.go
@@ -1,0 +1,354 @@
+package aws
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+
+	"github.com/go-toolset/pepperlint"
+	"github.com/go-toolset/pepperlint/rules"
+)
+
+// dynamodbImport path represents the AWS SDK for Go's import path
+// to dynamodb. It is quoted since this is visiting the ImportPathSpec,
+// which includes quotes.
+const dynamodbImport = `"github.com/aws/aws-sdk-go/service/dynamodb"`
+const dynamodbExpressionImport = "github.com/aws/aws-sdk-go/service/dynamodb/expression"
+const dynamodbName = "dynamodb"
+
+var expressionFields = map[string]object{
+	"QueryInput": object{
+		fields: map[string]object{
+			"FilterExpression": object{
+				expression: true,
+			},
+			"ExpressionAttributeNames": object{
+				expression: true,
+			},
+			"ExpressionAttributeValues": object{
+				expression: true,
+			},
+			"KeyConditionExpression": object{
+				expression: true,
+			},
+			"ProjectionExpression": object{
+				expression: true,
+			},
+		},
+	},
+
+	"ScanInput": object{
+		fields: map[string]object{
+			"FilterExpression": object{
+				expression: true,
+			},
+			"ExpressionAttributeNames": object{
+				expression: true,
+			},
+			"ExpressionAttributeValues": object{
+				expression: true,
+			},
+			"KeyConditionExpression": object{
+				expression: true,
+			},
+			"ProjectionExpression": object{
+				expression: true,
+			},
+		},
+	},
+}
+
+type object struct {
+	fields     map[string]object
+	expression bool
+}
+
+// DynamoDBExpressionRule is a rule that validates whether or not
+// an expressions package should have been used. Currently this will
+// use the expressionFields cache to check whether or not it is usable
+// by the expression package.
+type DynamoDBExpressionRule struct {
+	hasService bool
+	pkgName    string
+
+	fset   *token.FileSet
+	helper pepperlint.Helper
+}
+
+// NewDynamoDBExpressionRule returns a new rule with the given token.FileSet
+func NewDynamoDBExpressionRule(fset *token.FileSet) *DynamoDBExpressionRule {
+	return &DynamoDBExpressionRule{
+		fset: fset,
+	}
+}
+
+// ValidateFile will iterate through the import specs to determine whether or not
+// dynamodb package is being used. This will also peel off the pkg name incase of
+// package name overriding.
+func (r *DynamoDBExpressionRule) ValidateFile(file *ast.File) error {
+	r.hasService = false
+	r.pkgName = dynamodbName
+
+	for _, spec := range file.Imports {
+		if spec.Path.Value == dynamodbImport {
+			r.hasService = true
+
+			if spec.Name == nil {
+				return nil
+			}
+
+			r.pkgName = spec.Name.Name
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// ValidateAssignStmt will check if an assignment statement is using an expression
+// builder compatible structure and field. If a field is being used, it will see
+// if the expression builder is being used. If it is not, then an error will be
+// returned
+func (r DynamoDBExpressionRule) ValidateAssignStmt(stmt *ast.AssignStmt) error {
+	if !r.hasService {
+		return nil
+	}
+
+	exprs := []ast.Expr{}
+	for _, rhs := range stmt.Rhs {
+		switch t := rhs.(type) {
+		case *ast.CompositeLit:
+			spec := r.helper.GetTypeSpec(t.Type)
+			field, ok := expressionFields[spec.Name.Name]
+			if !ok {
+				continue
+			}
+
+			for _, elt := range t.Elts {
+				if es := r.IsUsingExpression(field, elt); len(es) > 0 {
+					exprs = append(exprs, es...)
+				}
+			}
+		default:
+			pepperlint.Log("TODO: dynamodb_expression_rule ValidateAssignStmt: %T", t)
+		}
+	}
+
+	batchErr := pepperlint.NewBatchError()
+	for _, expr := range exprs {
+		if !r.UsingExpressionsPackage(expr) {
+			batchErr.Add(pepperlint.NewErrorWrap(
+				r.fset,
+				expr,
+				fmt.Sprintf("expressions package can be used here"),
+			))
+		}
+	}
+
+	return batchErr.Return()
+}
+
+// IsUsingExpression will return a list of expressions that are an dynamodb.Expression.
+//
+// TODO: Figure out how to get field index
+// TODO: This does not check whether or not typed aliased expression builders or
+// if an expression string was returned by a function or method.
+func (r DynamoDBExpressionRule) IsUsingExpression(obj object, elt ast.Expr) []ast.Expr {
+	asts := []ast.Expr{}
+	if obj.expression {
+		return []ast.Expr{elt}
+	}
+
+	if elt == nil {
+		return nil
+	}
+
+	switch eltType := elt.(type) {
+	case *ast.BasicLit:
+		return nil
+	case *ast.CompositeLit:
+		spec := r.helper.GetTypeSpec(eltType.Type)
+		field, ok := expressionFields[spec.Name.Name]
+		if !ok {
+			return nil
+		}
+
+		for _, elt := range eltType.Elts {
+			if exprs := r.IsUsingExpression(field, elt); len(exprs) > 0 {
+				asts = append(asts, exprs...)
+			}
+		}
+
+		return asts
+	case *ast.KeyValueExpr:
+		ident, ok := eltType.Key.(*ast.Ident)
+		if !ok {
+			return nil
+		}
+
+		v, ok := obj.fields[ident.Name]
+		if !ok {
+			return nil
+		}
+
+		return r.IsUsingExpression(v, eltType.Value)
+	default:
+		pepperlint.Log("TODO: dynamodb_expression_rules.IsUsingExpression %T", eltType)
+	}
+
+	return nil
+}
+
+// AddRules will add the DeprecatedFieldRule to the given visitor
+func (r *DynamoDBExpressionRule) AddRules(visitorRules *pepperlint.Rules) {
+	rules := pepperlint.Rules{
+		AssignStmtRules: pepperlint.AssignStmtRules{r},
+		FileRules:       pepperlint.FileRules{r},
+	}
+
+	visitorRules.Merge(rules)
+}
+
+// WithCache will create a new helper with the given cache. This is used
+// to determine infomation about a specific ast.Node.
+func (r *DynamoDBExpressionRule) WithCache(cache *pepperlint.Cache) {
+	r.helper = pepperlint.NewHelper(cache)
+}
+
+// UsingExpressionsPackage checks to see if the expression package is being used.
+func (r DynamoDBExpressionRule) UsingExpressionsPackage(expr ast.Expr) bool {
+	f, ok := r.helper.PackagesCache.CurrentFile()
+	if !ok {
+		return false
+	}
+
+	pkgName, hasImport := getExpressionsPkgName(f)
+
+	if !hasImport {
+		return false
+	}
+
+	// TODO: now that the pkg name has been found, we need to walk the expr to ensure the package
+	// is being used
+	switch t := expr.(type) {
+	case *ast.CallExpr:
+		switch fun := t.Fun.(type) {
+		case *ast.SelectorExpr:
+			ident, ok := fun.X.(*ast.Ident)
+			if !ok {
+				return false
+			}
+
+			// This assumes that the ident expression is a imported function
+			if ident.Obj == nil {
+				// This may not be correct. For instance, the expression package could be
+				// used as a return item in a function. This would not capture that.
+				if ident.Name != pkgName {
+					return false
+				}
+
+				return true
+			}
+
+			// Does not have a declaration?
+			if ident.Obj.Decl == nil {
+				return false
+			}
+
+			switch decl := ident.Obj.Decl.(type) {
+			case *ast.AssignStmt:
+				fieldIndex := -1
+				for i, lhs := range decl.Lhs {
+
+					switch lhsType := lhs.(type) {
+					case *ast.Ident:
+						if lhsType.Name == ident.Name {
+							fieldIndex = i
+							break
+						}
+					default:
+						return false
+					}
+				}
+
+				if fieldIndex == -1 {
+					return false
+				}
+
+				rhs := decl.Rhs[fieldIndex]
+				if hasExpressionBuilder(pkgName, rhs) {
+					return true
+				}
+			}
+
+			return false
+		default:
+			pepperlint.Log("TODO: dynamodb_expression_rules.UsingExpressionsPackage %T", fun)
+		}
+	default:
+		pepperlint.Log("TODO: dynamodb_expression_rules.UsingExpressionsPackage %T", t)
+	}
+
+	return false
+}
+
+// CopyRule returns a new copy of the rule
+func (r DynamoDBExpressionRule) CopyRule() pepperlint.Rule {
+	return &DynamoDBExpressionRule{}
+}
+
+// WithFileSet sets the rule's file set
+func (r *DynamoDBExpressionRule) WithFileSet(fset *token.FileSet) {
+	r.fset = fset
+}
+
+// getExpressoinsPkgName will attempt to get the package name of the dynamodb.expressions
+// package. This needs to be done due to local overrides of package names. If a dynamodb import
+// path could not be found in the pepperlint.File, then false will be returned.
+func getExpressionsPkgName(f *pepperlint.File) (string, bool) {
+	foundImport := false
+	pkgName := ""
+	for imp, path := range f.Imports {
+		if path == dynamodbExpressionImport {
+			foundImport = true
+			pkgName = imp
+			break
+		}
+	}
+
+	return pkgName, foundImport
+}
+
+// hasExpressionBuilder will iterate through the expr AST and check to see if
+// an expression builder is within it.
+func hasExpressionBuilder(pkgName string, expr ast.Expr) bool {
+	switch t := expr.(type) {
+	case *ast.CallExpr:
+		return hasExpressionBuilder(pkgName, t.Fun)
+	case *ast.SelectorExpr:
+		ident, ok := t.X.(*ast.Ident)
+		if !ok {
+			return hasExpressionBuilder(pkgName, t.X)
+		}
+
+		if ident.Name != pkgName {
+			return false
+		}
+
+		if t.Sel.Name != "NewBuilder" {
+			return false
+		}
+
+		// This means that an expression.NewBuilder was called meaning
+		// that is being used to generate expressions.
+		return true
+	default:
+		pepperlint.Log("TODO: dynamodb_expression_rules.hasExpressionBuilder %T", t)
+	}
+
+	return false
+}
+
+func init() {
+	rules.Add("aws/dynamodb", &DynamoDBExpressionRule{})
+}

--- a/rules/aws/dynamodb_expression_rules_test.go
+++ b/rules/aws/dynamodb_expression_rules_test.go
@@ -1,0 +1,132 @@
+package aws
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"testing"
+
+	"github.com/go-toolset/pepperlint"
+)
+
+func TestDynamoDBExpressionRule(t *testing.T) {
+	cases := []struct {
+		name                string
+		code                string
+		rulesFn             func(fset *token.FileSet) *DynamoDBExpressionRule
+		pkgCache            pepperlint.Packages
+		expectedLineNumbers []int
+	}{
+		{
+			name: "simple",
+			code: `package foo
+			import (
+				"github.com/aws/aws-sdk-go/service/dynamodb"
+				"github.com/aws/aws-sdk-go/service/dynamodb/expression"
+			)
+
+			func bar() {
+				input := dynamodb.QueryInput{
+					FilterExpression: aws.String("some expr"),
+				}
+
+				filt := expression.Name("Artist").Equal(expression.Value("No One You Know"))
+				proj := expression.NamesList(expression.Name("SongTitle"), expression.Name("AlbumTitle"))
+				expr, err := expression.NewBuilder().WithFilter(filt).WithProjection(proj).Build()
+				if err != nil {
+					return
+				} 
+
+				input = dynamodb.QueryInput{
+					FilterExpression: expr.Filter(),
+				}
+			}`,
+			rulesFn: func(fset *token.FileSet) *DynamoDBExpressionRule {
+				r := NewDynamoDBExpressionRule(fset)
+				r.hasService = true
+				return r
+			},
+			pkgCache: pepperlint.Packages{
+				"": {
+					Files: pepperlint.Files{
+						{
+							Imports: map[string]string{
+								"dynamodb":   "github.com/aws/aws-sdk-go/service/dynamodb",
+								"expression": "github.com/aws/aws-sdk-go/service/dynamodb/expression",
+							},
+						},
+					},
+				},
+				"github.com/aws/aws-sdk-go/service/dynamodb": {
+					Files: pepperlint.Files{
+						{
+							TypeInfos: pepperlint.TypeInfos{
+								"QueryInput": {
+									Spec: &ast.TypeSpec{
+										Name: &ast.Ident{
+											Name: "QueryInput",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedLineNumbers: []int{
+				9,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			node, err := parser.ParseFile(fset, c.name, c.code, parser.ParseComments)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if node == nil {
+				t.Fatal("unexpected nil expr")
+			}
+
+			cache := &pepperlint.Cache{
+				Packages: c.pkgCache,
+			}
+
+			v := pepperlint.NewVisitor(fset, cache, c.rulesFn(fset))
+
+			// populate cache
+			ast.Walk(cache, node)
+
+			ast.Walk(v, node)
+
+			errs := []error{}
+			for _, err := range v.Errors {
+				e := err.(*pepperlint.BatchError)
+				es := e.Errors()
+				for _, err := range es {
+					errs = append(errs, err)
+				}
+			}
+
+			lines := []int{}
+			for _, err := range errs {
+				e := err.(*pepperlint.BatchError)
+				es := e.Errors()
+
+				for _, err := range es {
+					lerr := err.(pepperlint.LineNumber)
+					lines = append(lines, lerr.LineNumber())
+				}
+			}
+
+			t.Log(v.Errors)
+			if e, a := c.expectedLineNumbers, lines; !reflect.DeepEqual(e, a) {
+				t.Errorf("expected %v, but received %v", e, a)
+			}
+		})
+	}
+}

--- a/rules/core/deprecated/deprecated.go
+++ b/rules/core/deprecated/deprecated.go
@@ -1,4 +1,4 @@
-package core
+package deprecated
 
 import (
 	"go/ast"
@@ -11,31 +11,31 @@ import (
 
 const deprecatedPrefix = `// Deprecated:`
 
-// DeprecatedRule is a container for all deprecated rules
-type DeprecatedRule struct {
-	structRule *DeprecatedStructRule
-	fieldRule  *DeprecatedFieldRule
-	opRule     *DeprecatedOpRule
+// Rule is a container for all deprecated rules
+type Rule struct {
+	structRule *StructRule
+	fieldRule  *FieldRule
+	opRule     *OpRule
 }
 
-// NewDeprecatedRule will return a new set of deprecated rules
-func NewDeprecatedRule(fset *token.FileSet) *DeprecatedRule {
-	return &DeprecatedRule{
-		structRule: NewDeprecatedStructRule(fset),
-		fieldRule:  NewDeprecatedFieldRule(fset),
-		opRule:     NewDeprecatedOpRule(fset),
+// NewRule will return a new set of deprecated rules
+func NewRule(fset *token.FileSet) *Rule {
+	return &Rule{
+		structRule: NewStructRule(fset),
+		fieldRule:  NewFieldRule(fset),
+		opRule:     NewOpRule(fset),
 	}
 }
 
 // AddRules will add rules for every deprecate rule
-func (r *DeprecatedRule) AddRules(rules *pepperlint.Rules) {
+func (r *Rule) AddRules(rules *pepperlint.Rules) {
 	r.structRule.AddRules(rules)
 	r.fieldRule.AddRules(rules)
 	r.opRule.AddRules(rules)
 }
 
 // WithCache will add rules for every deprecate rule
-func (r *DeprecatedRule) WithCache(cache *pepperlint.Cache) {
+func (r *Rule) WithCache(cache *pepperlint.Cache) {
 	r.structRule.WithCache(cache)
 	r.fieldRule.WithCache(cache)
 	r.opRule.WithCache(cache)
@@ -43,21 +43,21 @@ func (r *DeprecatedRule) WithCache(cache *pepperlint.Cache) {
 
 // WithFileSet sets the file sets to each rule inside the deprecated
 // rule container.
-func (r DeprecatedRule) WithFileSet(fset *token.FileSet) {
+func (r Rule) WithFileSet(fset *token.FileSet) {
 	r.structRule.WithFileSet(fset)
 	r.fieldRule.WithFileSet(fset)
 	r.opRule.WithFileSet(fset)
 }
 
 // CopyRule satisfies the copy ruler interface to copy the
-// current DeprecatedRule
-func (r DeprecatedRule) CopyRule() pepperlint.Rule {
-	return &DeprecatedRule{
-		structRule: &DeprecatedStructRule{
+// current Rule
+func (r Rule) CopyRule() pepperlint.Rule {
+	return &Rule{
+		structRule: &StructRule{
 			visitedCallExpr: map[*ast.CallExpr]struct{}{},
 		},
-		fieldRule: &DeprecatedFieldRule{},
-		opRule:    &DeprecatedOpRule{},
+		fieldRule: &FieldRule{},
+		opRule:    &OpRule{},
 	}
 }
 
@@ -118,9 +118,9 @@ func hasDeprecatedComment(comments *ast.CommentGroup) bool {
 
 func init() {
 	// TODO: make it so the rule has a Pointer return interface or something
-	rules.Add("deprecated", &DeprecatedRule{
-		structRule: &DeprecatedStructRule{},
-		fieldRule:  &DeprecatedFieldRule{},
-		opRule:     &DeprecatedOpRule{},
+	rules.Add("core/deprecated", &Rule{
+		structRule: &StructRule{},
+		fieldRule:  &FieldRule{},
+		opRule:     &OpRule{},
 	})
 }

--- a/rules/core/deprecated/deprecated_field_rule_test.go
+++ b/rules/core/deprecated/deprecated_field_rule_test.go
@@ -1,4 +1,4 @@
-package core_test
+package deprecated_test
 
 import (
 	"go/ast"
@@ -7,14 +7,14 @@ import (
 	"testing"
 
 	"github.com/go-toolset/pepperlint"
-	"github.com/go-toolset/pepperlint/rules/core"
+	"github.com/go-toolset/pepperlint/rules/core/deprecated"
 )
 
 func TestDeprecateFieldRule(t *testing.T) {
 	cases := []struct {
 		name           string
 		code           string
-		rulesFn        func(fset *token.FileSet) *core.DeprecatedFieldRule
+		rulesFn        func(fset *token.FileSet) *deprecated.FieldRule
 		expectedErrors int
 	}{
 		{
@@ -34,8 +34,8 @@ func TestDeprecateFieldRule(t *testing.T) {
 					123,
 				}
 			}`,
-			rulesFn: func(fset *token.FileSet) *core.DeprecatedFieldRule {
-				return core.NewDeprecatedFieldRule(fset)
+			rulesFn: func(fset *token.FileSet) *deprecated.FieldRule {
+				return deprecated.NewFieldRule(fset)
 			},
 			expectedErrors: 2,
 		},
@@ -59,8 +59,8 @@ func TestDeprecateFieldRule(t *testing.T) {
 				f.DeprecatedField	= 2 + 1
 				n := f.DeprecatedField + 1
 			}`,
-			rulesFn: func(fset *token.FileSet) *core.DeprecatedFieldRule {
-				return core.NewDeprecatedFieldRule(fset)
+			rulesFn: func(fset *token.FileSet) *deprecated.FieldRule {
+				return deprecated.NewFieldRule(fset)
 			},
 			expectedErrors: 8,
 		},
@@ -80,8 +80,8 @@ func TestDeprecateFieldRule(t *testing.T) {
 				f.DeprecatedField = []int{4,5,6}
 				f.DeprecatedField = append(f.DeprecatedField, 7)
 			}`,
-			rulesFn: func(fset *token.FileSet) *core.DeprecatedFieldRule {
-				return core.NewDeprecatedFieldRule(fset)
+			rulesFn: func(fset *token.FileSet) *deprecated.FieldRule {
+				return deprecated.NewFieldRule(fset)
 			},
 			expectedErrors: 4,
 		},
@@ -109,8 +109,8 @@ func TestDeprecateFieldRule(t *testing.T) {
 			
 			func depOp(v int) {
 			}`,
-			rulesFn: func(fset *token.FileSet) *core.DeprecatedFieldRule {
-				return core.NewDeprecatedFieldRule(fset)
+			rulesFn: func(fset *token.FileSet) *deprecated.FieldRule {
+				return deprecated.NewFieldRule(fset)
 			},
 			expectedErrors: 3,
 		},
@@ -145,8 +145,8 @@ func TestDeprecateFieldRule(t *testing.T) {
 				return nil
 			}
 			`,
-			rulesFn: func(fset *token.FileSet) *core.DeprecatedFieldRule {
-				return core.NewDeprecatedFieldRule(fset)
+			rulesFn: func(fset *token.FileSet) *deprecated.FieldRule {
+				return deprecated.NewFieldRule(fset)
 			},
 			expectedErrors: 7,
 		},
@@ -220,8 +220,8 @@ func TestDeprecateFieldRule(t *testing.T) {
 			func checkArr(v []int32) {
 			}
 			`,
-			rulesFn: func(fset *token.FileSet) *core.DeprecatedFieldRule {
-				return core.NewDeprecatedFieldRule(fset)
+			rulesFn: func(fset *token.FileSet) *deprecated.FieldRule {
+				return deprecated.NewFieldRule(fset)
 			},
 			// TODO: Is this number correct?
 			expectedErrors: 22,

--- a/rules/core/deprecated/deprecated_op_rule.go
+++ b/rules/core/deprecated/deprecated_op_rule.go
@@ -1,4 +1,4 @@
-package core
+package deprecated
 
 import (
 	"fmt"
@@ -8,18 +8,18 @@ import (
 	"github.com/go-toolset/pepperlint"
 )
 
-// DeprecatedOpRule is used to walk and determine if an operation, whether function
+// OpRule is used to walk and determine if an operation, whether function
 // or method, being used is deprecated. If it is a deprecated operation, the appropriate
 // error will be returned.
-type DeprecatedOpRule struct {
+type OpRule struct {
 	fset           *token.FileSet
 	currentPkgName string
 	helper         pepperlint.Helper
 }
 
-// NewDeprecatedOpRule returns a new DeprecatedOpRule with the given file set.
-func NewDeprecatedOpRule(fset *token.FileSet) *DeprecatedOpRule {
-	return &DeprecatedOpRule{
+// NewOpRule returns a new OpRule with the given file set.
+func NewOpRule(fset *token.FileSet) *OpRule {
+	return &OpRule{
 		fset: fset,
 	}
 }
@@ -28,7 +28,7 @@ func NewDeprecatedOpRule(fset *token.FileSet) *DeprecatedOpRule {
 // whether or not it is an imported operation. With that, it'll get the
 // operation definition and this will take a look at the documentation
 // to determine if it is a deprecated operation.
-func (r *DeprecatedOpRule) isIdentDeprecated(ident *ast.Ident) error {
+func (r *OpRule) isIdentDeprecated(ident *ast.Ident) error {
 	var op *ast.FuncDecl
 	var ok bool
 
@@ -44,14 +44,14 @@ func (r *DeprecatedOpRule) isIdentDeprecated(ident *ast.Ident) error {
 	return nil
 }
 
-func (r *DeprecatedOpRule) getExternalPackageOp(ident *ast.Ident) (*ast.FuncDecl, bool) {
+func (r *OpRule) getExternalPackageOp(ident *ast.Ident) (*ast.FuncDecl, bool) {
 	return nil, false
 }
 
 // getInternalPackageOp will walk the nested parameters of the ident attempting to
 // grab the obj declaration. If the object declaration is of an *ast.FuncDecl, it
 // will the newly found object along with true.
-func (r *DeprecatedOpRule) getInternalPackageOp(ident *ast.Ident) (*ast.FuncDecl, bool) {
+func (r *OpRule) getInternalPackageOp(ident *ast.Ident) (*ast.FuncDecl, bool) {
 	if ident.Obj == nil {
 		return nil, false
 	}
@@ -68,7 +68,7 @@ func (r *DeprecatedOpRule) getInternalPackageOp(ident *ast.Ident) (*ast.FuncDecl
 	return nil, false
 }
 
-func (r *DeprecatedOpRule) getExternalPackageType(expr ast.Expr) ([]pepperlint.TypeInfo, bool) {
+func (r *OpRule) getExternalPackageType(expr ast.Expr) ([]pepperlint.TypeInfo, bool) {
 	infos := []pepperlint.TypeInfo{}
 
 	switch t := expr.(type) {
@@ -106,7 +106,7 @@ func (r *DeprecatedOpRule) getExternalPackageType(expr ast.Expr) ([]pepperlint.T
 	return infos, len(infos) > 0
 }
 
-func (r *DeprecatedOpRule) getExternalTypeSpec(rhs ast.Expr) (pepperlint.TypeInfo, bool) {
+func (r *OpRule) getExternalTypeSpec(rhs ast.Expr) (pepperlint.TypeInfo, bool) {
 	switch expr := rhs.(type) {
 	case *ast.CompositeLit:
 		exprType, ok := expr.Type.(*ast.SelectorExpr)
@@ -147,7 +147,7 @@ func (r *DeprecatedOpRule) getExternalTypeSpec(rhs ast.Expr) (pepperlint.TypeInf
 
 // getInternalPackageType will get associated type specs associated with the given
 // expression. The second parameter will be true if any type spec was found.
-func (r *DeprecatedOpRule) getInternalPackageType(expr ast.Expr) ([]pepperlint.TypeInfo, bool) {
+func (r *OpRule) getInternalPackageType(expr ast.Expr) ([]pepperlint.TypeInfo, bool) {
 	infos := []pepperlint.TypeInfo{}
 
 	switch t := expr.(type) {
@@ -183,7 +183,7 @@ func (r *DeprecatedOpRule) getInternalPackageType(expr ast.Expr) ([]pepperlint.T
 	return infos, len(infos) > 0
 }
 
-func (r *DeprecatedOpRule) getInternalTypeSpec(rhs ast.Expr) (*ast.TypeSpec, bool) {
+func (r *OpRule) getInternalTypeSpec(rhs ast.Expr) (*ast.TypeSpec, bool) {
 	switch expr := rhs.(type) {
 	case *ast.CompositeLit:
 		exprType, ok := expr.Type.(*ast.Ident)
@@ -219,7 +219,7 @@ func (r *DeprecatedOpRule) getInternalTypeSpec(rhs ast.Expr) (*ast.TypeSpec, boo
 // type spec off of the selector expression's X field. The type spec will be used
 // to determine whether or not that it is apart of the operation found via method name
 // and current package name.
-func (r *DeprecatedOpRule) isSelectorExprDeprecated(sel *ast.SelectorExpr) []error {
+func (r *OpRule) isSelectorExprDeprecated(sel *ast.SelectorExpr) []error {
 	methodName := sel.Sel.Name
 
 	var infos []pepperlint.TypeInfo
@@ -279,7 +279,7 @@ func (r *DeprecatedOpRule) isSelectorExprDeprecated(sel *ast.SelectorExpr) []err
 
 // ValidateAssignStmt will determine whether or not the RHS of an assignment expression
 // contains any deprecated operation.
-func (r *DeprecatedOpRule) ValidateAssignStmt(stmt *ast.AssignStmt) error {
+func (r *OpRule) ValidateAssignStmt(stmt *ast.AssignStmt) error {
 	batchError := pepperlint.NewBatchError()
 
 	for _, rhs := range stmt.Rhs {
@@ -298,7 +298,7 @@ func (r *DeprecatedOpRule) ValidateAssignStmt(stmt *ast.AssignStmt) error {
 }
 
 // ValidateCallExpr will determine if the operation in the CallExpr is deprecated.
-func (r *DeprecatedOpRule) ValidateCallExpr(expr *ast.CallExpr) error {
+func (r *OpRule) ValidateCallExpr(expr *ast.CallExpr) error {
 	batchError := pepperlint.NewBatchError()
 
 	switch fun := expr.Fun.(type) {
@@ -319,13 +319,13 @@ func (r *DeprecatedOpRule) ValidateCallExpr(expr *ast.CallExpr) error {
 
 // ValidatePackage is used to keep track of the current package scope that is
 // being traversed.
-func (r *DeprecatedOpRule) ValidatePackage(pkg *ast.Package) error {
+func (r *OpRule) ValidatePackage(pkg *ast.Package) error {
 	r.currentPkgName = pkg.Name
 	return nil
 }
 
 // AddRules will add the DeprecatedFieldRule to the given visitor
-func (r *DeprecatedOpRule) AddRules(visitorRules *pepperlint.Rules) {
+func (r *OpRule) AddRules(visitorRules *pepperlint.Rules) {
 	rules := pepperlint.Rules{
 		AssignStmtRules: pepperlint.AssignStmtRules{r},
 		CallExprRules:   pepperlint.CallExprRules{r},
@@ -337,12 +337,12 @@ func (r *DeprecatedOpRule) AddRules(visitorRules *pepperlint.Rules) {
 
 // WithCache will create a new helper with the given cache. This is used
 // to determine infomation about a specific ast.Node.
-func (r *DeprecatedOpRule) WithCache(cache *pepperlint.Cache) {
+func (r *OpRule) WithCache(cache *pepperlint.Cache) {
 	r.helper = pepperlint.NewHelper(cache)
 }
 
 // WithFileSet will set the token.FileSet to the rule allowing for more
 // in depth errors.
-func (r *DeprecatedOpRule) WithFileSet(fset *token.FileSet) {
+func (r *OpRule) WithFileSet(fset *token.FileSet) {
 	r.fset = fset
 }

--- a/rules/core/deprecated/deprecated_op_rule_test.go
+++ b/rules/core/deprecated/deprecated_op_rule_test.go
@@ -1,4 +1,4 @@
-package core_test
+package deprecated_test
 
 import (
 	"go/ast"
@@ -7,14 +7,14 @@ import (
 	"testing"
 
 	"github.com/go-toolset/pepperlint"
-	"github.com/go-toolset/pepperlint/rules/core"
+	"github.com/go-toolset/pepperlint/rules/core/deprecated"
 )
 
 func TestDeprecateOpRule(t *testing.T) {
 	cases := []struct {
 		name           string
 		code           string
-		rulesFn        func(fset *token.FileSet) *core.DeprecatedOpRule
+		rulesFn        func(fset *token.FileSet) *deprecated.OpRule
 		expectedErrors int
 	}{
 		{
@@ -51,8 +51,8 @@ func TestDeprecateOpRule(t *testing.T) {
 				v := DeprecatedFunction()
 			}
 			`,
-			rulesFn: func(fset *token.FileSet) *core.DeprecatedOpRule {
-				return core.NewDeprecatedOpRule(fset)
+			rulesFn: func(fset *token.FileSet) *deprecated.OpRule {
+				return deprecated.NewOpRule(fset)
 			},
 			expectedErrors: 4,
 		},

--- a/rules/core/deprecated/deprecated_struct_rule.go
+++ b/rules/core/deprecated/deprecated_struct_rule.go
@@ -1,4 +1,4 @@
-package core
+package deprecated
 
 import (
 	"fmt"
@@ -8,9 +8,9 @@ import (
 	"github.com/go-toolset/pepperlint"
 )
 
-// DeprecatedStructRule will validate that no deprecated struct
+// StructRule will validate that no deprecated struct
 // is used.
-type DeprecatedStructRule struct {
+type StructRule struct {
 	fset           *token.FileSet
 	currentPkgName string
 	helper         pepperlint.Helper
@@ -20,10 +20,10 @@ type DeprecatedStructRule struct {
 	visitedCallExpr map[*ast.CallExpr]struct{}
 }
 
-// NewDeprecatedStructRule return a newly instantiated DeprecatedStructRule
+// NewStructRule return a newly instantiated StructRule
 // with the given file set.
-func NewDeprecatedStructRule(fset *token.FileSet) *DeprecatedStructRule {
-	return &DeprecatedStructRule{
+func NewStructRule(fset *token.FileSet) *StructRule {
+	return &StructRule{
 		fset:            fset,
 		visitedCallExpr: map[*ast.CallExpr]struct{}{},
 	}
@@ -32,7 +32,7 @@ func NewDeprecatedStructRule(fset *token.FileSet) *DeprecatedStructRule {
 // isCompositeLitDeprecated will return whether or not a composite literal type has been
 // deprecated. The first parameter will be used to get the line number from the fileset if
 // an error occurred
-func (r DeprecatedStructRule) isCompositeLitDeprecated(node ast.Node, lit *ast.CompositeLit) []error {
+func (r StructRule) isCompositeLitDeprecated(node ast.Node, lit *ast.CompositeLit) []error {
 	switch t := lit.Type.(type) {
 	case *ast.Ident:
 		return r.isIdentDeprecated(node, t)
@@ -48,7 +48,7 @@ func (r DeprecatedStructRule) isCompositeLitDeprecated(node ast.Node, lit *ast.C
 
 // isSelectorExprDeprecated will see if a package.struct has been deprecated by getting the struct
 // info that was cached during the ValidateGenDecl call.
-func (r DeprecatedStructRule) isSelectorExprDeprecated(node ast.Node, expr *ast.SelectorExpr) error {
+func (r StructRule) isSelectorExprDeprecated(node ast.Node, expr *ast.SelectorExpr) error {
 	ident, ok := expr.X.(*ast.Ident)
 	if !ok {
 		return nil
@@ -79,7 +79,7 @@ func (r DeprecatedStructRule) isSelectorExprDeprecated(node ast.Node, expr *ast.
 
 // isIdentDeprecated will return an error upon finding a use of a deprecated structure.
 // The node parameter is used to determine a line number if an error occurred.
-func (r DeprecatedStructRule) isIdentDeprecated(node ast.Node, ident *ast.Ident) []error {
+func (r StructRule) isIdentDeprecated(node ast.Node, ident *ast.Ident) []error {
 	var spec *ast.TypeSpec
 	errs := []error{}
 
@@ -173,7 +173,7 @@ func (r DeprecatedStructRule) isIdentDeprecated(node ast.Node, ident *ast.Ident)
 
 // ValidateAssignStmt will take a look to see if a deprecated structure is
 // being assigned to a given variable.
-func (r DeprecatedStructRule) ValidateAssignStmt(stmt *ast.AssignStmt) error {
+func (r StructRule) ValidateAssignStmt(stmt *ast.AssignStmt) error {
 	batchError := pepperlint.NewBatchError()
 
 	// check to see if any struct initialized objects contain any deprecated field
@@ -187,7 +187,7 @@ func (r DeprecatedStructRule) ValidateAssignStmt(stmt *ast.AssignStmt) error {
 	return batchError.Return()
 }
 
-func (r DeprecatedStructRule) validateAssignStmt(expr ast.Expr, rhs ast.Expr) []error {
+func (r StructRule) validateAssignStmt(expr ast.Expr, rhs ast.Expr) []error {
 	switch t := rhs.(type) {
 	case *ast.CompositeLit:
 		if errs := r.deprecatedStructUsage(expr, t.Type); len(errs) > 0 {
@@ -206,7 +206,7 @@ func (r DeprecatedStructRule) validateAssignStmt(expr ast.Expr, rhs ast.Expr) []
 	case *ast.UnaryExpr:
 		return r.validateAssignStmt(expr, t.X)
 	default:
-		pepperlint.Log("TODO: RHS DeprecatedStructRule.ValidateAssignStmt %T %v\n", t, t)
+		pepperlint.Log("TODO: RHS StructRule.ValidateAssignStmt %T %v\n", t, t)
 	}
 
 	return nil
@@ -215,7 +215,7 @@ func (r DeprecatedStructRule) validateAssignStmt(expr ast.Expr, rhs ast.Expr) []
 // deprecatedStructUsage will determine if a struct is being used in an assignment
 // statement. The RHS parameter is used to grab the line number if an error has
 // occurred.
-func (r DeprecatedStructRule) deprecatedStructUsage(rhs ast.Expr, expr ast.Expr) []error {
+func (r StructRule) deprecatedStructUsage(rhs ast.Expr, expr ast.Expr) []error {
 	errs := []error{}
 	switch tstruct := expr.(type) {
 	case *ast.Ident:
@@ -279,7 +279,7 @@ func (r DeprecatedStructRule) deprecatedStructUsage(rhs ast.Expr, expr ast.Expr)
 
 // checkTypeAliases will ensure that a type alias is not type aliasing
 // a deprecated structure.
-func (r DeprecatedStructRule) checkTypeAliases(rhs ast.Node, expr ast.Expr) []error {
+func (r StructRule) checkTypeAliases(rhs ast.Node, expr ast.Expr) []error {
 	errs := []error{}
 
 	switch t := expr.(type) {
@@ -323,7 +323,7 @@ func (r DeprecatedStructRule) checkTypeAliases(rhs ast.Node, expr ast.Expr) []er
 }
 
 // ValidateCallExpr will ensure a deprecated struct is not being passed as a parameter
-func (r DeprecatedStructRule) ValidateCallExpr(expr *ast.CallExpr) error {
+func (r StructRule) ValidateCallExpr(expr *ast.CallExpr) error {
 	batchError := pepperlint.NewBatchError()
 	if _, ok := r.visitedCallExpr[expr]; ok {
 		return nil
@@ -342,7 +342,7 @@ func (r DeprecatedStructRule) ValidateCallExpr(expr *ast.CallExpr) error {
 	return batchError.Return()
 }
 
-func (r DeprecatedStructRule) validateCallExpr(node ast.Node, arg ast.Expr) []error {
+func (r StructRule) validateCallExpr(node ast.Node, arg ast.Expr) []error {
 	errs := []error{}
 
 	switch t := arg.(type) {
@@ -377,7 +377,7 @@ func (r DeprecatedStructRule) validateCallExpr(node ast.Node, arg ast.Expr) []er
 }
 
 // ValidateReturnStmt will validate that return items are not deprecated structures.
-func (r DeprecatedStructRule) ValidateReturnStmt(stmt *ast.ReturnStmt) error {
+func (r StructRule) ValidateReturnStmt(stmt *ast.ReturnStmt) error {
 	batchError := pepperlint.NewBatchError()
 
 	for _, result := range stmt.Results {
@@ -392,7 +392,7 @@ func (r DeprecatedStructRule) ValidateReturnStmt(stmt *ast.ReturnStmt) error {
 			}
 
 		default:
-			pepperlint.Log("TODO: DeprecatedStructRule.ValidateReturnStmt: %T", t)
+			pepperlint.Log("TODO: StructRule.ValidateReturnStmt: %T", t)
 		}
 	}
 
@@ -401,7 +401,7 @@ func (r DeprecatedStructRule) ValidateReturnStmt(stmt *ast.ReturnStmt) error {
 
 // ValidateFuncDecl will validate function declaractions and ensure no
 // deprecated structure is being used
-func (r DeprecatedStructRule) ValidateFuncDecl(decl *ast.FuncDecl) error {
+func (r StructRule) ValidateFuncDecl(decl *ast.FuncDecl) error {
 	batchError := pepperlint.NewBatchError()
 
 	for _, param := range decl.Type.Params.List {
@@ -474,13 +474,13 @@ func (r DeprecatedStructRule) ValidateFuncDecl(decl *ast.FuncDecl) error {
 
 // ValidatePackage will set the current package name to the package that is currently
 // being visited.
-func (r *DeprecatedStructRule) ValidatePackage(pkg *ast.Package) error {
+func (r *StructRule) ValidatePackage(pkg *ast.Package) error {
 	r.currentPkgName = pkg.Name
 	return nil
 }
 
 // ValidateTypeSpec will ensure that the type spec's type isn't a deprecated structure.
-func (r DeprecatedStructRule) ValidateTypeSpec(spec *ast.TypeSpec) error {
+func (r StructRule) ValidateTypeSpec(spec *ast.TypeSpec) error {
 	batchError := pepperlint.NewBatchError()
 
 	switch t := spec.Type.(type) {
@@ -489,14 +489,14 @@ func (r DeprecatedStructRule) ValidateTypeSpec(spec *ast.TypeSpec) error {
 			batchError.Add(err)
 		}
 	default:
-		pepperlint.Log("TODO: DeprecatedStructRule.ValidateTypeSpec %T", t)
+		pepperlint.Log("TODO: StructRule.ValidateTypeSpec %T", t)
 	}
 
 	return batchError.Return()
 }
 
 // ValidateValueSpec will check structures used as values are not deprecated structs.
-func (r DeprecatedStructRule) ValidateValueSpec(spec *ast.ValueSpec) error {
+func (r StructRule) ValidateValueSpec(spec *ast.ValueSpec) error {
 	batchError := pepperlint.NewBatchError()
 
 	switch specType := spec.Type.(type) {
@@ -520,7 +520,7 @@ func (r DeprecatedStructRule) ValidateValueSpec(spec *ast.ValueSpec) error {
 
 // ValidateBinaryExpr will ensure no deprecated struct is being used on either the LHS
 // or RHS of the expression.
-func (r DeprecatedStructRule) ValidateBinaryExpr(expr *ast.BinaryExpr) error {
+func (r StructRule) ValidateBinaryExpr(expr *ast.BinaryExpr) error {
 	batchError := pepperlint.NewBatchError()
 
 	if es := r.deprecatedStructUsage(expr.X, expr.X); len(es) > 0 {
@@ -533,8 +533,8 @@ func (r DeprecatedStructRule) ValidateBinaryExpr(expr *ast.BinaryExpr) error {
 	return batchError.Return()
 }
 
-// AddRules will add the DeprecatedStructRule to the given visitor
-func (r *DeprecatedStructRule) AddRules(visitorRules *pepperlint.Rules) {
+// AddRules will add the StructRule to the given visitor
+func (r *StructRule) AddRules(visitorRules *pepperlint.Rules) {
 	rules := pepperlint.Rules{
 		AssignStmtRules: pepperlint.AssignStmtRules{r},
 		BinaryExprRules: pepperlint.BinaryExprRules{r},
@@ -551,12 +551,12 @@ func (r *DeprecatedStructRule) AddRules(visitorRules *pepperlint.Rules) {
 
 // WithCache will create a new helper with the given cache. This is used
 // to determine infomation about a specific ast.Node.
-func (r *DeprecatedStructRule) WithCache(cache *pepperlint.Cache) {
+func (r *StructRule) WithCache(cache *pepperlint.Cache) {
 	r.helper = pepperlint.NewHelper(cache)
 }
 
 // WithFileSet will set the token.FileSet to the rule allowing for more
 // in depth errors.
-func (r *DeprecatedStructRule) WithFileSet(fset *token.FileSet) {
+func (r *StructRule) WithFileSet(fset *token.FileSet) {
 	r.fset = fset
 }

--- a/rules/core/deprecated/deprecated_struct_rule_test.go
+++ b/rules/core/deprecated/deprecated_struct_rule_test.go
@@ -1,4 +1,4 @@
-package core_test
+package deprecated_test
 
 import (
 	"go/ast"
@@ -7,14 +7,14 @@ import (
 	"testing"
 
 	"github.com/go-toolset/pepperlint"
-	"github.com/go-toolset/pepperlint/rules/core"
+	"github.com/go-toolset/pepperlint/rules/core/deprecated"
 )
 
-func TestDeprecatedStructRule(t *testing.T) {
+func TestStructRule(t *testing.T) {
 	cases := []struct {
 		name           string
 		code           string
-		rulesFn        func(fset *token.FileSet) *core.DeprecatedStructRule
+		rulesFn        func(fset *token.FileSet) *deprecated.StructRule
 		expectedErrors int
 	}{
 		{
@@ -33,8 +33,8 @@ func deprecated() interface{} {
 	}
 }
 			`,
-			rulesFn: func(fset *token.FileSet) *core.DeprecatedStructRule {
-				return core.NewDeprecatedStructRule(fset)
+			rulesFn: func(fset *token.FileSet) *deprecated.StructRule {
+				return deprecated.NewStructRule(fset)
 			},
 			expectedErrors: 1,
 		},
@@ -66,8 +66,8 @@ func deprecated() interface{} {
 	if moo == nil {
 	}
 }`,
-			rulesFn: func(fset *token.FileSet) *core.DeprecatedStructRule {
-				return core.NewDeprecatedStructRule(fset)
+			rulesFn: func(fset *token.FileSet) *deprecated.StructRule {
+				return deprecated.NewStructRule(fset)
 			},
 			expectedErrors: 3,
 		},
@@ -106,8 +106,8 @@ func deprecated() interface{} {
 		{},
 	}
 }`,
-			rulesFn: func(fset *token.FileSet) *core.DeprecatedStructRule {
-				return core.NewDeprecatedStructRule(fset)
+			rulesFn: func(fset *token.FileSet) *deprecated.StructRule {
+				return deprecated.NewStructRule(fset)
 			},
 			expectedErrors: 4,
 		},
@@ -144,8 +144,8 @@ func deprecated() interface{} {
 
 	return moo
 }`,
-			rulesFn: func(fset *token.FileSet) *core.DeprecatedStructRule {
-				return core.NewDeprecatedStructRule(fset)
+			rulesFn: func(fset *token.FileSet) *deprecated.StructRule {
+				return deprecated.NewStructRule(fset)
 			},
 			expectedErrors: 6,
 		},
@@ -181,8 +181,8 @@ func deprecated() interface{} {
 
 func check(v interface{}) {
 }`,
-			rulesFn: func(fset *token.FileSet) *core.DeprecatedStructRule {
-				return core.NewDeprecatedStructRule(fset)
+			rulesFn: func(fset *token.FileSet) *deprecated.StructRule {
+				return deprecated.NewStructRule(fset)
 			},
 			expectedErrors: 6,
 		},
@@ -203,8 +203,8 @@ func DeprecatedReturn() Foo {
 	return Foo{}
 }
 `,
-			rulesFn: func(fset *token.FileSet) *core.DeprecatedStructRule {
-				return core.NewDeprecatedStructRule(fset)
+			rulesFn: func(fset *token.FileSet) *deprecated.StructRule {
+				return deprecated.NewStructRule(fset)
 			},
 			expectedErrors: 3,
 		},

--- a/visitor.go
+++ b/visitor.go
@@ -56,13 +56,13 @@ func (v *Visitor) Visit(node ast.Node) ast.Visitor {
 	switch t := node.(type) {
 	case *ast.Package:
 		for k := range t.Files {
-			v.PackagesCache.currentPkgImportPath = GetImportPathFromFullPath(filepath.Dir(k))
+			v.PackagesCache.CurrentPkgImportPath = GetImportPathFromFullPath(filepath.Dir(k))
 			break
 		}
 
 		v.visitPackage(t)
 	case *ast.File:
-		v.PackagesCache.currentFile = t
+		v.PackagesCache.CurrentASTFile = t
 
 		v.visitFile(t)
 	case ast.Decl:


### PR DESCRIPTION
Adds aws rules folder including the DynamoDBExpression rule set.

Deprecated core rules are now added via core/deprecated